### PR TITLE
Make updates (tests/)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,25 +1,39 @@
 TOPDIR=$(PWD)
 include $(TOPDIR)/include.mk
 
+all: main test
+
 main: main.o $(ARCHIVE)
 	$(CC) $(CFLAGS) $(INCLUDES) $^ -o $@
+
+.PHONY: test
+test: $(ARCHIVE)
+	make -C $(TESTS_DIR)
+
+.PHONY:
+run_tests: test
+	make -C $(TESTS_DIR) run
 
 archive: $(ARCHIVE)
 
 $(ARCHIVE): lib/list.o
 	ar -r $(ARCHIVE) lib/*.o
 
-%.o: %.c
-	$(CC) -c $(CFLAGS) $(INCLUDES) $< -o $@
-
 .PHONY: tags
-tags:
+tags: ctags etags
+
+.PHONY: ctags
+ctags:
 	find $(TOPDIR) -type f -name "*.[ch]" | xargs ctags
+
+.PHONY: etags
+etags:
 	find -type f -name "*.[ch]" -exec etags -a {} \;
 
 .PHONY: clean
 clean:
 	rm -f  *.a *.o lib/*.o main tags TAGS
+	make -C $(TESTS_DIR) clean
 
 .PHONY: help
 help:
@@ -27,6 +41,10 @@ help:
 	@echo "main       compile main binary from main.c"
 	@echo "archive    export all library functions as $(ARCHIVE) that your application"
 	@echo "           can linked against"
+	@echo
+	@echo "============ Test Targets ============"
+	@echo "test       compile all the tests"
+	@echo "run_tests  run all the tests"
 	@echo
 	@echo "============ Cleaning Targets ============"
 	@echo "clean      clean the source by deleting all object/archive/tag files"

--- a/include.mk
+++ b/include.mk
@@ -1,3 +1,7 @@
 CFLAGS=-g -Wall
 INCLUDES=-I $(TOPDIR)/include
-ARCHIVE=ds_algo.a
+ARCHIVE=$(TOPDIR)/ds_algo.a
+TESTS_DIR=$(TOPDIR)/tests
+
+%.o: %.c
+	$(CC) -c $(CFLAGS) $(INCLUDES) $< -o $@

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,0 +1,28 @@
+TOPDIR=..
+include $(TOPDIR)/include.mk
+
+SRC_FILES=$(shell ls *.c)
+OBJ_FILES=$(SRC_FILES:.c=.o)
+BINS=$(SRC_FILES:.c=)
+
+all: slist slist_prob1
+
+slist_prob1: slist_prob1.o
+	$(CC) $< $(ARCHIVE) -o $@
+
+slist: slist.o
+	$(CC) $< $(ARCHIVE) -o $@
+
+.PHONY: run
+run:
+	@echo "=================================================="
+	@echo "Singly Linked List Begin"
+	@echo "=================================================="	
+
+	./slist
+	./slist_prob1
+	@echo "=================== END =========================="
+
+.PHONY: clean
+clean:
+	rm -f $(OBJ_FILES) $(BINS)


### PR DESCRIPTION
- Makefile (all): new target (calls main and test).
  (test, run_tests): new targets to compile and run tests/.
  (tags, ctags, etags): split tags into ctags and etags so that
  users can only compile for their editor or all of them.
  (help): updated help
- tests/Makefile: compiles and runs all the tests/
- include.mk: add new variables and generic *.o target
  (ARCHIVE): name of .a archive to export
  (TESTS_DIR): Points to directory contains tests/
